### PR TITLE
feat: Wire up hosted Supabase + Cloudflare Pages deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,10 +27,10 @@ NEXT_PUBLIC_APP_NAME="Studio Co-op"
 EXPO_PUBLIC_API_URL=http://localhost:3001
 EXPO_PUBLIC_APP_NAME="Studio Co-op"
 
-# Supabase (if using Supabase hosted)
-# NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-# NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
-# SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+# Supabase (hosted — required for production)
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # Optional: Storage (S3-compatible for media uploads)
 # S3_ENDPOINT=https://...

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -135,3 +135,35 @@ GitHub Actions runs on every push and PR:
 - Build web app
 
 See `.github/workflows/ci.yml`.
+
+## Cloudflare Pages Deployment
+
+### Setup
+
+1. Connect the repo to Cloudflare Pages
+2. Set build settings:
+   - **Build command:** `cd apps/web && npx @cloudflare/next-on-pages`
+   - **Build output directory:** `apps/web/.vercel/output/static`
+   - **Root directory:** `/`
+3. Add environment variables in Cloudflare dashboard:
+   - `NEXT_PUBLIC_SUPABASE_URL`
+   - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+   - `NEXT_PUBLIC_APP_URL` (your Pages URL)
+   - `NEXT_PUBLIC_APP_NAME`
+
+### Local Preview
+
+```bash
+cd apps/web
+pnpm build:cf-pages
+pnpm preview:cf
+```
+
+### Supabase Hosted
+
+The project uses hosted Supabase (project: `lomrjhkneodiowwarrzz`, region: Asia-Pacific).
+
+To push migrations to the hosted instance:
+```bash
+npx supabase db push --project-ref lomrjhkneodiowwarrzz
+```

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,10 @@
     "lint": "next lint",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "build:static": "NEXT_CONFIG_FILE=next.config.static.ts next build",
+    "build:cf-pages": "npx @cloudflare/next-on-pages",
+    "preview:cf": "npx wrangler pages dev .vercel/output/static"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.2",

--- a/apps/web/src/lib/supabase/admin.ts
+++ b/apps/web/src/lib/supabase/admin.ts
@@ -1,0 +1,19 @@
+import { createClient } from '@supabase/supabase-js'
+
+// Server-only admin client with service role key
+// DO NOT use in browser code or client components
+export function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY or NEXT_PUBLIC_SUPABASE_URL')
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+}

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -1,0 +1,10 @@
+name = "studio-coop"
+compatibility_date = "2024-09-23"
+compatibility_flags = ["nodejs_compat"]
+
+# Cloudflare Pages with next-on-pages
+# Build: npx @cloudflare/next-on-pages
+# Output: .vercel/output/static
+
+[vars]
+NEXT_PUBLIC_APP_NAME = "Studio Co-op"

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -2,7 +2,7 @@
 # Docs: https://supabase.com/docs/guides/cli/config
 
 [project]
-id = "studio-coop"
+id = "lomrjhkneodiowwarrzz"
 
 [api]
 enabled = true


### PR DESCRIPTION
## Changes

### Supabase Integration
- Uncommented and promoted Supabase env vars in `.env.example` (now required for production)
- Added `apps/web/src/lib/supabase/admin.ts` — server-only admin client using service role key
- Updated `supabase/config.toml` with hosted project ID (`lomrjhkneodiowwarrzz`, Asia-Pacific region)
- Existing client/server/middleware Supabase setup was already in place ✅

### Cloudflare Pages
- Added `apps/web/wrangler.toml` with Node.js compat flags
- Added `build:cf-pages` and `preview:cf` scripts to web app
- Added Cloudflare Pages deployment docs to `DEPLOYMENT.md`

### Existing Infrastructure (no changes needed)
- 6 Supabase migrations already exist (initial schema through notifications)
- Supabase SSR client, server client, and middleware already wired up
- Next.js static export config already exists (`next.config.static.ts`)
- Marketing site and landing page already exist

### Notes
- Real credentials are in `apps/web/.env.local` (gitignored)
- To push migrations to hosted Supabase: `npx supabase db push --project-ref lomrjhkneodiowwarrzz`
